### PR TITLE
[CIVIS-11444] set PUID/PGID in docker-compose + rebuild from latest base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,7 @@ RUN echo "**** install Python 3.12 ****" && \
   apt-get install -y \
     python3.12 \
     python3.12-dev \
-    python3.12-venv \
-    wget && \
-  echo "**** install yq ****" && \
-  YQ_VERSION="v4.43.1" && \
-  wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \
-  chmod +x /usr/local/bin/yq && \
+    python3.12-venv && \
   update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN echo "**** install Python 3.12 ****" && \
   apt-get install -y \
     python3.12 \
     python3.12-dev \
-    python3.12-venv && \
+    python3.12-venv \
+    wget && \
   echo "**** install yq ****" && \
   YQ_VERSION="v4.43.1" && \
   wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN echo "**** install Python 3.12 ****" && \
     python3.12 \
     python3.12-dev \
     python3.12-venv && \
-  apt update && \
-  apt install yq -y && \
+  echo "**** install yq ****" && \
+  YQ_VERSION="v4.43.1" && \
+  wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \
+  chmod +x /usr/local/bin/yq && \
   update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN echo "**** install Python 3.12 ****" && \
   apt-get install -y \
     python3.12 \
     python3.12-dev \
-    python3.12-venv && \
+    python3.12-venv \
+    yq && \
   update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN echo "**** install Python 3.12 ****" && \
     python3.12 \
     python3.12-dev \
     python3.12-venv && \
+  apt update && \
   apt install yq -y && \
   update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN echo "**** install Python 3.12 ****" && \
   apt-get install -y \
     python3.12 \
     python3.12-dev \
-    python3.12-venv \
-    yq && \
+    python3.12-venv && \
+  apt install yq -y && \
   update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
         - VERSION=${VERSION:-4.102.1}
         - CODE_RELEASE=${CODE_RELEASE:-4.102.1}
     environment:
-      - PUID=${PUID:-0}
-      - PGID=${PGID:-0}
+      - PUID=${PUID:-123654}
+      - PGID=${PGID:-123654}
       - TZ=${TZ:-America/Chicago}
       - PROXY_DOMAIN=${PROXY_DOMAIN:-}
       - DEFAULT_WORKSPACE=${DEFAULT_WORKSPACE:-/workspace}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         - linux/amd64
       args:
         - ECR_ACCOUNT_ID=${ECR_ACCOUNT_ID:-0123456789012}
-        - BASE_IMAGE_TAG=${BASE_IMAGE_TAG:-latest}
+        - BASE_IMAGE_TAG=${BASE_IMAGE_TAG:-jammy-latest}
         - VERSION=${VERSION:-4.102.1}
         - CODE_RELEASE=${CODE_RELEASE:-4.102.1}
     environment:


### PR DESCRIPTION
## Description

- small change in docker-compose to set a default PGID and PUID.
- also fixes the base image tag default value in docker-compose
- mostly just need to trigger a build to use the newest jammy-latest tag from the base image.
  - https://github.com/civisanalytics/docker-linuxserver-ubuntu-fips/pull/4

## Context, Consequences, & Considerations

Required: Please step through the following list, pausing at each item to consider your change in relation to the item's context.
Check the box to mark that it applies, and enter your relevant notes under the item.

- [ ] Security: This has security implications. This includes (but not limited to) adding users, modifying user/app permissions, network rules/policies, changing a system interconnection, or changing an authorization strategy.
  - [x] This PR does not require security review. These changes are part of a project plan that has already undergone security review. The link is provided below.
  - [ ] This PR requires security review. Add the `security` label to this PR then request a review from the [Security Code Reviewers Team](https://github.com/orgs/civisanalytics/teams/security-code-reviewers).

>

- [ ] Execution: This change requires commands to be run outside of the normal merge.

>

- [ ] Impact: This change may cause service interruptions.

>

- [x] Testing: How did you test this change (unit tests, acceptance tests, etc.)? Did you do any manual testing?

> manual

- [ ] Testing: How will you confirm this change once it's merged?

>

- [ ] Documentation: Documentation to reflect this change has been added to Confluence or Zendesk.

>

- [x] **All items of the checklist have been considered and this PR description is complete.**
